### PR TITLE
Level the playing field

### DIFF
--- a/phoenix/config/prod.exs
+++ b/phoenix/config/prod.exs
@@ -17,7 +17,7 @@ config :pete_phoenix, PetePhoenix.Endpoint,
   cache_static_manifest: "priv/static/manifest.json"
 
 # Do not print debug messages in production
-config :logger, level: :info
+config :logger, level: :error
 
 # ## SSL Support
 #

--- a/phoenix/web/router.ex
+++ b/phoenix/web/router.ex
@@ -3,10 +3,6 @@ defmodule PetePhoenix.Router do
 
   pipeline :browser do
     plug :accepts, ["html"]
-    plug :fetch_session
-    plug :fetch_flash
-    plug :protect_from_forgery
-    plug :put_secure_browser_headers
   end
 
   pipeline :api do


### PR DESCRIPTION
Unless the others are doing the same, the Phoenix app should not be doing expensive operations like CSRF protection, fetching the session, and heavy IO logging. I have disabled these in this PR. If the others are doing this work, feel free to close, otherwise we should merge and re-run the test :) Thanks!
